### PR TITLE
Add basic game engine and start game logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,12 +158,18 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 ## 🧱 Suggested Tasks for Codex
 1. Scaffold `/client` and `/server` folders with entry files. ✅
 2. Implement `roomManager.js` to handle player joins and room tracking. ✅
-3. Build `gameEngine.js` to manage the full game state lifecycle.
+3. Build `gameEngine.js` to manage the full game state lifecycle. ✅
 4. Set up `socket.io` server and connect React client.
 5. Create basic UI for joining/creating room and nickname entry.
 6. Implement game phases one at a time with full broadcast logic.
 7. Write tests for role assignment, voting logic, and win condition checks.
 
 👉 Keep `TODO.md` updated with ongoing progress and upcoming tasks.
+
+### Development Best Practices
+- Run `npm start` to launch the server during local development.
+- Keep the game logic strictly on the server; clients only send user actions.
+- Add unit tests for utilities and the game engine as they are implemented.
+- Regularly update `TODO.md` when a step is completed or a new one appears.
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,9 +3,10 @@
 ## Completed
 - Scaffolded client and server folders with entry files.
 - Implemented room manager and initial socket handlers.
+- Created basic game engine with role assignment and policy logic.
+- Hooked up `START_GAME` socket event.
 
 ## Next Steps
-- Build `gameEngine.js` for managing game state and role assignment.
-- Hook up remaining socket events such as `START_GAME` and game-phase actions.
-- Create basic React UI components for gameplay phases.
-- Write unit tests for utilities and room management.
+- Implement vote and policy socket events using the game engine.
+- Expand React UI components for each gameplay phase.
+- Write unit tests for game engine, utilities, and room management.

--- a/server/gameEngine.js
+++ b/server/gameEngine.js
@@ -3,6 +3,16 @@
  * All logic should be server-side and authoritative.
  */
 const { ROLES, PHASES } = require('../shared/constants.js');
+const { assignRoles, shuffleDeck } = require('../shared/utils.js');
+
+const BASE_POLICY_DECK = [
+  ...Array(6).fill('LIBERAL'),
+  ...Array(11).fill('FASCIST'),
+];
+
+function createPolicyDeck() {
+  return shuffleDeck([...BASE_POLICY_DECK]);
+}
 
 /**
  * Example structure of a game state object.
@@ -23,22 +33,89 @@ const { ROLES, PHASES } = require('../shared/constants.js');
  * Starts a new game for a given room.
  */
 function startGame(room) {
-  // TODO: assign roles and initialize game state
-  room.game = {};
+  room.players = assignRoles(room.players);
+  room.game = {
+    players: room.players.map((p) => ({
+      id: p.id,
+      name: p.name,
+      role: p.role,
+      alive: true,
+      hasVoted: false,
+      vote: null,
+    })),
+    phase: PHASES.NOMINATE,
+    presidentIndex: 0,
+    chancellorIndex: null,
+    failedElections: 0,
+    policyDeck: createPolicyDeck(),
+    enactedPolicies: { liberal: 0, fascist: 0 },
+    history: [],
+    settings: { playerCount: room.players.length },
+  };
 }
 
 /**
  * Handles player votes.
  */
 function handleVote(room, playerId, vote) {
-  // TODO: process vote and update state
+  const state = room.game;
+  if (!state || state.phase !== PHASES.VOTE) return;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player || player.hasVoted) return;
+
+  player.hasVoted = true;
+  player.vote = vote;
+
+  if (state.players.every((p) => p.hasVoted)) {
+    const yesVotes = state.players.filter((p) => p.vote === true).length;
+    const passed = yesVotes > state.players.length / 2;
+
+    state.history.push({
+      type: 'VOTE',
+      result: passed,
+      votes: state.players.map((p) => ({ id: p.id, vote: p.vote })),
+    });
+
+    state.players.forEach((p) => {
+      p.hasVoted = false;
+      p.vote = null;
+    });
+
+    if (passed) {
+      state.phase = PHASES.POLICY;
+      state.failedElections = 0;
+    } else {
+      state.failedElections += 1;
+      if (state.failedElections >= 3) {
+        const autoPolicy = state.policyDeck.pop();
+        processPolicy(room, autoPolicy);
+        state.failedElections = 0;
+      }
+      state.presidentIndex = (state.presidentIndex + 1) % state.players.length;
+      state.phase = PHASES.NOMINATE;
+    }
+  }
 }
 
 /**
  * Processes a selected policy.
  */
 function processPolicy(room, policy) {
-  // TODO: update policy track and trigger powers
+  const state = room.game;
+  if (!state) return;
+
+  if (policy === 'LIBERAL') {
+    state.enactedPolicies.liberal += 1;
+  } else {
+    state.enactedPolicies.fascist += 1;
+  }
+
+  state.history.push({ type: 'POLICY', policy });
+
+  state.chancellorIndex = null;
+  state.presidentIndex = (state.presidentIndex + 1) % state.players.length;
+  state.phase = PHASES.NOMINATE;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- implement startGame, voting and policy logic in `gameEngine.js`
- add `START_GAME` socket handler on server
- update task list with new progress and plans
- expand instructions in `AGENTS.md`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684dc8d06cb0832aa01bff3f7d52c68e