### PR TITLE
Add basic client event handlers and UI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,9 @@
 
 ## Completed in this wave
 - Implemented vote and policy socket events using the game engine.
+- Added client handlers for role assignment, vote and policy events.
+- Created basic UI elements for casting votes and selecting policies.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase.
-- Add client handlers for vote and policy events.
 - Write unit tests for game engine, utilities, and room management.

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -1,16 +1,50 @@
 import React, { useContext } from 'react';
 import { GameStateContext } from './GameStateContext.js';
+import { MESSAGE_TYPES } from '../shared/messages.js';
+import { PHASES } from '../shared/constants.js';
 
 /**
  * Main game UI. Renders based on current game state from context.
  * TODO: Add nomination, voting, policy selection, and powers UI.
  */
 export default function Game() {
-  const { gameState } = useContext(GameStateContext);
+  const { socket, gameState, role, policyPrompt } = useContext(GameStateContext);
+
+  const roomCode = gameState?.code || gameState?.roomCode;
+
+  const castVote = (vote) => {
+    if (socket && roomCode) {
+      socket.emit(MESSAGE_TYPES.CAST_VOTE, { roomCode, vote });
+    }
+  };
+
+  const choosePolicy = (policy) => {
+    if (socket && roomCode) {
+      socket.emit(MESSAGE_TYPES.POLICY_CHOICE, { roomCode, policy });
+    }
+  };
 
   return (
     <div>
       <h2>Game In Progress</h2>
+      {role && <p>Your role: {role}</p>}
+
+      {gameState?.game?.phase === PHASES.VOTE && (
+        <div>
+          <h3>Cast Your Vote</h3>
+          <button onClick={() => castVote(true)}>Ja!</button>
+          <button onClick={() => castVote(false)}>Nein!</button>
+        </div>
+      )}
+
+      {policyPrompt && (
+        <div>
+          <h3>Select Policy</h3>
+          <button onClick={() => choosePolicy('LIBERAL')}>Liberal</button>
+          <button onClick={() => choosePolicy('FASCIST')}>Fascist</button>
+        </div>
+      )}
+
       <pre>{JSON.stringify(gameState, null, 2)}</pre>
       {/* TODO: replace with proper components for each game phase */}
     </div>


### PR DESCRIPTION
## Summary
- wire up client-side socket handlers for role, vote, and policy events
- expose player role and policy prompts in context
- add simple voting and policy selection UI
- record progress in TODO list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dcb65a6bc832a89cb48d34d4e3afb