### PR TITLE
Implement policy drawing and discard flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,8 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 
 ### Rule Implementation Notes
 - Term limits for Chancellor eligibility implemented (Rules: Election & Chancellor Eligibility).
-- Policy draw/discard mechanics and presidential powers remain TODO.
+- Basic policy draw/discard flow implemented. Deck reshuffles the discard pile when fewer than three cards remain (Rules: Legislative Session, Policy Deck Management).
+- Presidential powers and veto power remain TODO.
 
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,10 @@
 - Added nomination phase logic with server handler and React UI.
 - Added win condition checks and GAME_OVER handling on server and client.
 - Enforced Chancellor eligibility term limits according to rules.
+- Implemented policy draw/discard flow with deck reshuffle and updated client prompts.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase (policy draw, powers).
 - Implement server logic for special powers (investigate, execute, etc.).
 - Write unit tests for game engine, utilities, and room management.
-- Add policy draw/discard flow and deck management with reshuffle when needed.
+- Add veto power after five fascist policies.

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -70,8 +70,11 @@ export default function Game() {
       {policyPrompt && !gameState.gameOver && (
         <div>
           <h3>Select Policy</h3>
-          <button onClick={() => choosePolicy('LIBERAL')}>Liberal</button>
-          <button onClick={() => choosePolicy('FASCIST')}>Fascist</button>
+          {policyPrompt.map((p, idx) => (
+            <button key={idx} onClick={() => choosePolicy(p)}>
+              {p}
+            </button>
+          ))}
         </div>
       )}
 

--- a/client/GameStateContext.js
+++ b/client/GameStateContext.js
@@ -12,7 +12,7 @@ export default function GameStateProvider({ children }) {
   const [socket, setSocket] = useState(null);
   const [gameState, setGameState] = useState({});
   const [role, setRole] = useState(null);
-  const [policyPrompt, setPolicyPrompt] = useState(false);
+  const [policyPrompt, setPolicyPrompt] = useState(null);
   const [playerId, setPlayerId] = useState(null);
 
   useEffect(() => {
@@ -49,12 +49,12 @@ export default function GameStateProvider({ children }) {
       setGameState((prev) => ({ ...prev, lastVote: result }));
     });
 
-    sock.on(MESSAGE_TYPES.POLICY_PROMPT, () => {
-      setPolicyPrompt(true);
+    sock.on(MESSAGE_TYPES.POLICY_PROMPT, (data) => {
+      setPolicyPrompt(data.policies);
     });
 
     sock.on(MESSAGE_TYPES.POLICY_RESULT, (res) => {
-      setPolicyPrompt(false);
+      setPolicyPrompt(null);
       setGameState((prev) => ({
         ...prev,
         game: {


### PR DESCRIPTION
## Summary
- implement policy deck reshuffle and draw logic in game engine
- add beginPolicyPhase and handlePolicyChoice handlers
- send policy prompts with card lists to clients
- update client context and UI to choose from policies
- update rule notes and TODO list

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(runs server)*

------
https://chatgpt.com/codex/tasks/task_e_684de9cd205c832a959693d5a9c75cd7