### PR TITLE
Implement remaining presidential powers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,8 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Chancellor term limit logic now enforced in `gameEngine.js`.
 - Investigate Loyalty implemented; remember to send POWER_PROMPT only to the acting President and POWER_RESULT only to them.
 - Special Election power implemented. The President selects any alive player for the next Presidential Candidate. After that election, presidency returns left of the original President.
+- Policy Peek power implemented. The top three policies are shown privately to the President.
+- Execution power implemented. The President may kill a player; if Hitler is executed the Liberals win. POWER_RESULT is broadcast to all players.
 
 ---
 
@@ -179,8 +181,10 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 ### Rule Implementation Notes
 - Term limits for Chancellor eligibility implemented (Rules: Election & Chancellor Eligibility).
 - Basic policy draw/discard flow implemented. Deck reshuffles the discard pile when fewer than three cards remain (Rules: Legislative Session, Policy Deck Management).
-- Investigate Loyalty power implemented with secrecy preserved (Rules: Presidential Powers - Investigate Loyalty). Other powers and veto power remain TODO.
+- Investigate Loyalty power implemented with secrecy preserved (Rules: Presidential Powers - Investigate Loyalty).
 - Special Election power implemented (Rules: Presidential Powers - Call Special Election). Presidency order resumes to the left of the original President after the election.
+- Policy Peek power implemented (Rules: Presidential Powers - Policy Peek). President privately views top three policies.
+- Execution power implemented (Rules: Presidential Powers - Execution). Killing Hitler results in an immediate Liberal victory.
 
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,10 @@
 - Implemented policy draw/discard flow with deck reshuffle and updated client prompts.
 - Added initial implementation of Investigate Loyalty power with server handler and client prompt.
 - Added Special Election presidential power with server logic and client UI.
+- Implemented Policy Peek power with automatic handling.
+- Implemented Execution power with victory checks.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase (policy draw, powers).
- - Implement remaining special powers (Policy Peek, Execution).
 - Write unit tests for game engine, utilities, and room management.
 - Add veto power after five fascist policies.

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -109,6 +109,19 @@ export default function Game() {
           <p>Special Election: {powerResult.targetId} will be the next President.</p>
         </div>
       )}
+      {powerResult && powerResult.power === 'POLICY_PEEK' && (
+        <div>
+          <p>Top Policies: {powerResult.policies.join(', ')}</p>
+        </div>
+      )}
+      {powerResult && powerResult.power === 'EXECUTION' && (
+        <div>
+          <p>{powerResult.targetName} has been executed.</p>
+          {powerResult.gameOver && (
+            <p>Game Over - {powerResult.gameOver.winner} win: {powerResult.gameOver.reason}</p>
+          )}
+        </div>
+      )}
 
       <pre>{JSON.stringify(gameState, null, 2)}</pre>
       {/* TODO: replace with proper components for each game phase */}


### PR DESCRIPTION
## Summary
- add Policy Peek and Execution handling in `gameEngine`
- broadcast power results and process Policy Peek automatically in `server/index`
- display results of Policy Peek and Execution in the client
- document new completed tasks
- update agent guidance with notes on new powers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dee97ee50832aba7fa20080b0d30c