### PR TITLE
Implement server checks for executed players

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Execution power implemented (Rules: Presidential Powers - Execution). Killing Hitler results in an immediate Liberal victory.
 - Initial fascist knowledge reveal implemented according to player count (Rules: Setup - Eyes Closed Sequence).
 - Basic logging added on server for game start, nominations, votes, policies, vetoes, and powers.
+- Executed player restrictions enforced. Dead players cannot vote or hold office and presidency skips them. UI still needs cues.
 
 
 
@@ -209,6 +210,6 @@ Codex agents and contributors must ensure every gameplay feature aligns with **R
 7. **Veto Power** – Allow veto requests only after five Fascist policies and handle tracker advancement if a veto occurs.
 8. **Eligibility and Term Limits** – Enforce that the last elected President and Chancellor cannot be nominated as Chancellor (except when only five players remain, where only the last Chancellor is barred).
 9. **Logging & Validation** – Log all state changes and cross-check against RULES.md when implementing new features.
-10. **Executed Players** – Ensure executed players cannot speak or hold office. UI still needs cues and restrictions.
+10. **Executed Players** – Server enforces that executed players cannot vote or hold office. UI still needs cues and restrictions.
 
 Before merging any change, verify the checklist above and update tests to cover new logic.

--- a/TODO.md
+++ b/TODO.md
@@ -23,8 +23,10 @@
 ## Completed in this wave
 - Implemented initial fascist/Hitler knowledge sharing on game start.
 - Added simple server logging for key state changes.
+- Enforced executed player restrictions: dead players cannot vote or hold office and presidency skips them. UI hides vote panel when executed.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase (policy draw, powers).
 - Write unit tests for game engine, utilities, and room management.
 - Improve lobby UI to display joined players and error messages.
+- Add visual indicators for executed players in all UI components and test presidency rotation logic.

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -10,6 +10,8 @@ import { PHASES } from '../shared/constants.js';
 export default function Game() {
   const { socket, gameState, role, roleInfo, policyPrompt, powerPrompt, powerResult, playerId, vetoPrompt } = useContext(GameStateContext);
 
+  const me = gameState?.game?.players?.find((p) => p.id === playerId);
+
   const roomCode = gameState?.code || gameState?.roomCode;
 
   const castVote = (vote) => {
@@ -73,6 +75,8 @@ export default function Game() {
         <p>Hitler is {roleInfo.hitler.name}</p>
       )}
 
+      {me && !me.alive && <p>You have been executed and may not act.</p>}
+
       {!gameState.gameOver && gameState?.game?.phase === PHASES.NOMINATE && (
         playerId === gameState.game.players[gameState.game.presidentIndex]?.id ? (
           <div>
@@ -90,13 +94,15 @@ export default function Game() {
         )
       )}
 
-      {!gameState.gameOver && gameState?.game?.phase === PHASES.VOTE && (
-        <div>
-          <h3>Cast Your Vote</h3>
-          <button onClick={() => castVote(true)}>Ja!</button>
-          <button onClick={() => castVote(false)}>Nein!</button>
-        </div>
-      )}
+      {!gameState.gameOver &&
+        gameState?.game?.phase === PHASES.VOTE &&
+        me?.alive && (
+          <div>
+            <h3>Cast Your Vote</h3>
+            <button onClick={() => castVote(true)}>Ja!</button>
+            <button onClick={() => castVote(false)}>Nein!</button>
+          </div>
+        )}
 
       {policyPrompt && !gameState.gameOver && (
         <div>

--- a/server/gameEngine.js
+++ b/server/gameEngine.js
@@ -73,6 +73,12 @@ function advancePresidency(state) {
   } else {
     state.presidentIndex = (state.presidentIndex + 1) % state.players.length;
   }
+  // Skip executed players
+  let safety = 0;
+  while (!state.players[state.presidentIndex].alive && safety < state.players.length) {
+    state.presidentIndex = (state.presidentIndex + 1) % state.players.length;
+    safety += 1;
+  }
 }
 
 /**
@@ -192,13 +198,13 @@ function handleVote(room, playerId, vote) {
   if (!state || state.phase !== PHASES.VOTE) return null;
 
   const player = state.players.find((p) => p.id === playerId);
-  if (!player || player.hasVoted) return null;
+  if (!player || !player.alive || player.hasVoted) return null;
 
   player.hasVoted = true;
   player.vote = vote;
 
-  if (state.players.every((p) => p.hasVoted)) {
-    const yesVotes = state.players.filter((p) => p.vote === true).length;
+  if (state.players.filter((p) => p.alive).every((p) => p.hasVoted)) {
+    const yesVotes = state.players.filter((p) => p.alive && p.vote === true).length;
     const passed = yesVotes > state.players.length / 2;
 
     state.history.push({


### PR DESCRIPTION
## Summary
- skip executed players during presidency rotation
- block votes from executed players and hide vote UI if dead
- show message when executed
- update AGENTS and TODO

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684df2df982c832aaf489f18872befc5