### PR TITLE
Improve lobby and start flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Initial fascist knowledge reveal implemented according to player count (Rules: Setup - Eyes Closed Sequence).
 - Basic logging added on server for game start, nominations, votes, policies, vetoes, and powers.
 - Executed player restrictions enforced. Dead players cannot vote or hold office and presidency skips them. UI still needs cues.
+- Lobby now displays joined players and room code. Only the host may start the game once five or more players have joined. Clients stay in the lobby until the `GAME_START` message arrives.
 
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,9 +24,11 @@
 - Implemented initial fascist/Hitler knowledge sharing on game start.
 - Added simple server logging for key state changes.
 - Enforced executed player restrictions: dead players cannot vote or hold office and presidency skips them. UI hides vote panel when executed.
+- Improved lobby UI to list players, show room code and allow host to start the game. Errors now display in Lobby.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase (policy draw, powers).
 - Write unit tests for game engine, utilities, and room management.
-- Improve lobby UI to display joined players and error messages.
 - Add visual indicators for executed players in all UI components and test presidency rotation logic.
+- Implement a routing/state machine to manage Lobby vs Game views.
+- Add ability for players to leave a room and handle disconnect cleanup.

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,18 +1,22 @@
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import Lobby from './Lobby.jsx';
 import Game from './Game.jsx';
-import GameStateProvider from './GameStateContext.js';
+import GameStateProvider, { GameStateContext } from './GameStateContext.js';
 
 /**
  * Root component. Switches between Lobby and Game views.
  * TODO: Add proper routing or state machine to manage phases.
  */
-export default function App() {
-  const [inGame, setInGame] = useState(false); // replace with real state logic
+function AppContent() {
+  const { gameState } = useContext(GameStateContext);
+  const inGame = !!gameState?.game;
+  return inGame ? <Game /> : <Lobby />;
+}
 
+export default function App() {
   return (
     <GameStateProvider>
-      {inGame ? <Game /> : <Lobby onStart={() => setInGame(true)} />}
+      <AppContent />
     </GameStateProvider>
   );
 }

--- a/client/Lobby.jsx
+++ b/client/Lobby.jsx
@@ -6,26 +6,32 @@ import { MESSAGE_TYPES } from '../shared/messages.js';
  * Lobby view for entering a name and room code.
  * Provides buttons to create or join a room.
  */
-export default function Lobby({ onStart }) {
-  const { socket } = useContext(GameStateContext);
+export default function Lobby() {
+  const { socket, gameState, playerId } = useContext(GameStateContext);
   const [name, setName] = useState('');
   const [roomCode, setRoomCode] = useState('');
 
   const createRoom = () => {
-    // TODO: Implement create room logic
     if (socket) socket.emit(MESSAGE_TYPES.CREATE_ROOM, { name });
-    onStart();
   };
 
   const joinRoom = () => {
-    // TODO: Implement join room logic
     if (socket) socket.emit(MESSAGE_TYPES.JOIN_ROOM, { name, roomCode });
-    onStart();
   };
+
+  const startGame = () => {
+    if (socket && gameState?.code) {
+      socket.emit(MESSAGE_TYPES.START_GAME, { roomCode: gameState.code });
+    }
+  };
+
+  const isHost = gameState?.players?.[0]?.id === playerId;
+  const joined = gameState?.players && gameState.players.some((p) => p.id === playerId);
 
   return (
     <div>
       <h1>Secret Hitler</h1>
+      {joined && <p>Room Code: {gameState.code}</p>}
       <input
         type="text"
         placeholder="Your name"
@@ -38,8 +44,26 @@ export default function Lobby({ onStart }) {
         value={roomCode}
         onChange={(e) => setRoomCode(e.target.value)}
       />
-      <button onClick={createRoom}>Create Room</button>
-      <button onClick={joinRoom}>Join Room</button>
+      {!joined && (
+        <>
+          <button onClick={createRoom}>Create Room</button>
+          <button onClick={joinRoom}>Join Room</button>
+        </>
+      )}
+      {joined && (
+        <>
+          <h3>Players</h3>
+          <ul>
+            {gameState.players.map((p) => (
+              <li key={p.id}>{p.name}</li>
+            ))}
+          </ul>
+          {isHost && gameState.players.length >= 5 && (
+            <button onClick={startGame}>Start Game</button>
+          )}
+          {gameState.error && <p>{gameState.error}</p>}
+        </>
+      )}
     </div>
   );
 }

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -15,6 +15,7 @@ function createRoom(hostPlayer) {
     roomCode = generateRoomCode();
   }
   rooms[roomCode] = {
+    code: roomCode,
     players: [hostPlayer],
     game: null,
   };


### PR DESCRIPTION
## Summary
- enhance lobby UI with player list and host-controlled start
- auto-switch between lobby and game based on GAME_START event
- store room code in room state
- update project guidelines and task list

## Testing
- `npm start` *(server starts)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684df3edfb60832ab2d2f2da9065db56