### PR TITLE
Implement auto policy broadcast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Executed player restrictions enforced. Dead players cannot vote or hold office and presidency skips them. UI still needs cues.
 - Lobby now displays joined players and room code. Only the host may start the game once five or more players have joined. Clients stay in the lobby until the `GAME_START` message arrives.
 - Players may leave a room before the game starts via `LEAVE_ROOM`. Disconnects during an active game are not yet handled beyond removal from the room.
+- Auto policy results from the Election Tracker are now broadcast to all players to maintain sync.
 
 
 
@@ -225,7 +226,7 @@ Feature | Status | Notes
 --- | --- | ---
 Room creation & join flow | ✅ | Rooms can be created and joined from the lobby
 Role assignment | ✅ | Roles assigned on game start with correct knowledge share
-Game phases (nominate → vote → policy) | Partial | Basic flow works but auto-policy from failed elections is not broadcast
+Game phases (nominate → vote → policy) | ✅ | Auto policy results broadcast and core flow works
 Vote counting | ✅ | Majority check counts only alive players
 Policy deck handling (draw/discard/enact) | ✅ | Deck reshuffles the discard pile when needed
 Fascist powers | ✅ | Investigate, Special Election, Policy Peek, Execution and Veto implemented
@@ -235,8 +236,7 @@ UI reactivity | Partial | React components exist but largely debug oriented
 Socket message handling | ✅ | Client and server handle defined message types
 Rules compliance (RULES.md) | Partial | Most rules enforced; disconnect logic remains
 
-Identified blockers to reach playtest:
-- Broadcast auto policy results
+- Identified blockers to reach playtest:
 - Handle disconnects mid-game
 - Improve phase-specific UI
 - Add automated tests for rule enforcement

--- a/TODO.md
+++ b/TODO.md
@@ -29,9 +29,9 @@
 ## Completed in this wave
 - Added ability for players to leave a room before the game starts. Client UI now includes "Leave Room" buttons and server handles `LEAVE_ROOM` events.
 - Fixed vote majority logic to count only alive players when determining if an election passes.
+- Broadcast auto policy results when the election tracker triggers a random policy enactment so clients stay in sync.
 
 ## Next Steps
-- Broadcast results of auto policies triggered by the election tracker so all clients stay in sync.
 - Handle players leaving or disconnecting during an active game and decide whether play continues or ends.
 - Expand React UI components for each gameplay phase (policy draw, powers, prompts) to improve reactivity.
 - Write unit tests for the game engine and helpers to enforce rule compliance and prevent regressions.

--- a/server/gameEngine.js
+++ b/server/gameEngine.js
@@ -208,6 +208,7 @@ function handleVote(room, playerId, vote) {
   if (alivePlayers.every((p) => p.hasVoted)) {
     const yesVotes = alivePlayers.filter((p) => p.vote === true).length;
     const passed = yesVotes > alivePlayers.length / 2;
+    let autoResult = null;
 
     state.history.push({
       type: 'VOTE',
@@ -244,19 +245,21 @@ function handleVote(room, playerId, vote) {
       state.failedElections += 1;
       if (state.failedElections >= 3) {
         const autoPolicy = drawPolicies(state, 1)[0];
-        processPolicy(room, autoPolicy);
+        autoResult = processPolicy(room, autoPolicy);
         state.failedElections = 0;
         state.lastPresidentId = null;
         state.lastChancellorId = null;
+      } else {
+        advancePresidency(state);
+        state.phase = PHASES.NOMINATE;
       }
-      advancePresidency(state);
-      state.phase = PHASES.NOMINATE;
     }
 
     return {
       completed: true,
       passed,
       votes: state.history[state.history.length - 1].votes,
+      ...(autoResult ? { autoResult } : {}),
     };
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -102,6 +102,13 @@ io.on('connection', (socket) => {
       if (result.gameOver) {
         io.to(roomCode).emit(MESSAGE_TYPES.GAME_OVER, result.gameOver);
       }
+      if (result.autoResult) {
+        logEvent(roomCode, 'POLICY_ENACTED', result.autoResult.enactedPolicies);
+        io.to(roomCode).emit(MESSAGE_TYPES.POLICY_RESULT, result.autoResult);
+        if (result.autoResult.gameOver) {
+          io.to(roomCode).emit(MESSAGE_TYPES.GAME_OVER, result.autoResult.gameOver);
+        }
+      }
       if (room.game.phase === PHASES.POLICY) {
         const policies = gameEngine.beginPolicyPhase(room);
         const presidentId = room.game.players[room.game.presidentIndex].id;


### PR DESCRIPTION
## Summary
- broadcast auto policy results triggered by the election tracker
- fix double presidency advance during auto policy
- update TODOs and project progress notes

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc87068c832abf547b4b969e74d7