### PR TITLE
Implement disconnect handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Basic logging added on server for game start, nominations, votes, policies, vetoes, and powers.
 - Executed player restrictions enforced. Dead players cannot vote or hold office and presidency skips them. UI still needs cues.
 - Lobby now displays joined players and room code. Only the host may start the game once five or more players have joined. Clients stay in the lobby until the `GAME_START` message arrives.
-- Players may leave a room before the game starts via `LEAVE_ROOM`. Disconnects during an active game are not yet handled beyond removal from the room.
+- Players may leave a room before the game starts via `LEAVE_ROOM`. Disconnecting during a game now marks that player as executed and ends the game if Hitler disconnects.
 - Auto policy results from the Election Tracker are now broadcast to all players to maintain sync.
 
 
@@ -234,9 +234,8 @@ Win condition checks | ✅ | All victory conditions evaluated in the engine
 Game state broadcast & sync | Partial | Core events sent via socket but some state changes are not emitted
 UI reactivity | Partial | React components exist but largely debug oriented
 Socket message handling | ✅ | Client and server handle defined message types
-Rules compliance (RULES.md) | Partial | Most rules enforced; disconnect logic remains
+Rules compliance (RULES.md) | Partial | Most rules enforced; disconnecting players are treated as executions
 
 - Identified blockers to reach playtest:
-- Handle disconnects mid-game
 - Improve phase-specific UI
 - Add automated tests for rule enforcement

--- a/TODO.md
+++ b/TODO.md
@@ -30,8 +30,8 @@
 - Added ability for players to leave a room before the game starts. Client UI now includes "Leave Room" buttons and server handles `LEAVE_ROOM` events.
 - Fixed vote majority logic to count only alive players when determining if an election passes.
 - Broadcast auto policy results when the election tracker triggers a random policy enactment so clients stay in sync.
+- Disconnecting players during an active game are now treated as executed. If Hitler disconnects the Liberals win. Room state updates are emitted.
 
 ## Next Steps
-- Handle players leaving or disconnecting during an active game and decide whether play continues or ends.
 - Expand React UI components for each gameplay phase (policy draw, powers, prompts) to improve reactivity.
 - Write unit tests for the game engine and helpers to enforce rule compliance and prevent regressions.


### PR DESCRIPTION
## Summary
- treat disconnecting players as executed
- import roles for disconnect logic
- update tasks and agent notes

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684dfda52914832abfd5498ed0695013