### PR TITLE
Wave update: show nominations and vote results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Lobby now displays joined players and room code. Only the host may start the game once five or more players have joined. Clients stay in the lobby until the `GAME_START` message arrives.
 - Players may leave a room before the game starts via `LEAVE_ROOM`. Disconnecting during a game now marks that player as executed and ends the game if Hitler disconnects.
 - Auto policy results from the Election Tracker are now broadcast to all players to maintain sync.
+- Client tracks current nomination and displays vote results to improve transparency.
 
 
 
@@ -232,7 +233,7 @@ Policy deck handling (draw/discard/enact) | ✅ | Deck reshuffles the discard pi
 Fascist powers | ✅ | Investigate, Special Election, Policy Peek, Execution and Veto implemented
 Win condition checks | ✅ | All victory conditions evaluated in the engine
 Game state broadcast & sync | Partial | Core events sent via socket but some state changes are not emitted
-UI reactivity | Partial | React components exist but largely debug oriented
+UI reactivity | Partial | React components exist but largely debug oriented; nomination and vote results now shown
 Socket message handling | ✅ | Client and server handle defined message types
 Rules compliance (RULES.md) | Partial | Most rules enforced; disconnecting players are treated as executions
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,10 @@
 - Fixed vote majority logic to count only alive players when determining if an election passes.
 - Broadcast auto policy results when the election tracker triggers a random policy enactment so clients stay in sync.
 - Disconnecting players during an active game are now treated as executed. If Hitler disconnects the Liberals win. Room state updates are emitted.
+- Tracked current nomination on the client and display which players are up for election.
+- Added vote result display showing each player's Ja!/Nein choice.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase (policy draw, powers, prompts) to improve reactivity.
 - Write unit tests for the game engine and helpers to enforce rule compliance and prevent regressions.
+- Add board UI showing enacted policies and election tracker progress.

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -8,7 +8,19 @@ import { PHASES } from '../shared/constants.js';
  * TODO: Add nomination, voting, policy selection, and powers UI.
  */
 export default function Game() {
-  const { socket, gameState, role, roleInfo, policyPrompt, powerPrompt, powerResult, playerId, vetoPrompt, leaveRoom } = useContext(GameStateContext);
+  const {
+    socket,
+    gameState,
+    role,
+    roleInfo,
+    policyPrompt,
+    powerPrompt,
+    powerResult,
+    playerId,
+    vetoPrompt,
+    nomination,
+    leaveRoom,
+  } = useContext(GameStateContext);
 
   const me = gameState?.game?.players?.find((p) => p.id === playerId);
 
@@ -83,6 +95,21 @@ export default function Game() {
       )}
 
       {me && !me.alive && <p>You have been executed and may not act.</p>}
+
+      {nomination && (
+        <p>
+          {
+            gameState.game.players.find((p) => p.id === nomination.presidentId)
+              ?.name
+          }{' '}
+          nominated{' '}
+          {
+            gameState.game.players.find((p) => p.id === nomination.nomineeId)
+              ?.name
+          }
+          {' '}as Chancellor.
+        </p>
+      )}
 
       {!gameState.gameOver && gameState?.game?.phase === PHASES.NOMINATE && (
         playerId === gameState.game.players[gameState.game.presidentIndex]?.id ? (
@@ -169,6 +196,22 @@ export default function Game() {
           {powerResult.gameOver && (
             <p>Game Over - {powerResult.gameOver.winner} win: {powerResult.gameOver.reason}</p>
           )}
+        </div>
+      )}
+
+      {gameState.lastVote && (
+        <div>
+          <h3>Vote Result: {gameState.lastVote.passed ? 'Government elected' : 'Rejected'}</h3>
+          <ul>
+            {gameState.lastVote.votes.map((v) => {
+              const name = gameState.game.players.find((p) => p.id === v.id)?.name || v.id;
+              return (
+                <li key={v.id}>
+                  {name}: {v.vote ? 'Ja' : 'Nein'}
+                </li>
+              );
+            })}
+          </ul>
         </div>
       )}
 

--- a/client/GameStateContext.js
+++ b/client/GameStateContext.js
@@ -18,6 +18,7 @@ export default function GameStateProvider({ children }) {
   const [powerPrompt, setPowerPrompt] = useState(null);
   const [powerResult, setPowerResult] = useState(null);
   const [playerId, setPlayerId] = useState(null);
+  const [nomination, setNomination] = useState(null);
 
   const resetState = () => {
     setGameState({});
@@ -27,6 +28,7 @@ export default function GameStateProvider({ children }) {
     setVetoPrompt(false);
     setPowerPrompt(null);
     setPowerResult(null);
+    setNomination(null);
   };
 
   useEffect(() => {
@@ -53,14 +55,16 @@ export default function GameStateProvider({ children }) {
       setGameState((prev) => ({ ...prev, game }));
     });
 
-    sock.on(MESSAGE_TYPES.VOTE_REQUEST, () => {
+    sock.on(MESSAGE_TYPES.VOTE_REQUEST, ({ presidentId, nomineeId }) => {
       setGameState((prev) => ({
         ...prev,
         game: { ...prev.game, phase: PHASES.VOTE },
       }));
+      setNomination({ presidentId, nomineeId });
     });
 
     sock.on(MESSAGE_TYPES.VOTE_RESULT, (result) => {
+      setNomination(null);
       setGameState((prev) => ({ ...prev, lastVote: result }));
     });
 
@@ -128,6 +132,7 @@ export default function GameStateProvider({ children }) {
         powerPrompt,
         powerResult,
         playerId,
+        nomination,
         vetoPrompt,
         leaveRoom,
       }}


### PR DESCRIPTION
## Summary
- display nominated chancellor during elections
- show each player's vote result when voting concludes
- track nomination state client side
- update TODO and agent notes

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684dfeb64ee8832a808821a3775714b0