### PR TITLE
Add PlayerList UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Auto policy results from the Election Tracker are now broadcast to all players to maintain sync.
 - Client tracks current nomination and displays vote results to improve transparency.
 - Basic board UI added showing policy tracks and election tracker progress.
+- Player list component added showing seating order with President and Chancellor markers.
 
 
 
@@ -236,6 +237,7 @@ Fascist powers | ✅ | Investigate, Special Election, Policy Peek, Execution and
 Win condition checks | ✅ | All victory conditions evaluated in the engine
 Game state broadcast & sync | Partial | Core events sent via socket but some state changes are not emitted
 UI reactivity | Partial | Basic board component added; nomination and vote results shown but styling minimal
+Player list display | ✅ | PlayerList component shows seating order with President and Chancellor markers
 Socket message handling | ✅ | Client and server handle defined message types
 Rules compliance (RULES.md) | Partial | Most rules enforced; disconnecting players are treated as executions
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,8 +34,9 @@
 - Tracked current nomination on the client and display which players are up for election.
 - Added vote result display showing each player's Ja!/Nein choice.
 - Implemented board UI showing enacted policies and election tracker progress.
+- Added PlayerList component showing seating order with President and Chancellor markers.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase (policy draw, powers, prompts) to improve reactivity.
 - Write unit tests for the game engine and helpers to enforce rule compliance and prevent regressions.
-- Add player list component to display seating order and indicate current President and Chancellor.
+- Improve UI styling for board and player list.

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -3,6 +3,7 @@ import { GameStateContext } from './GameStateContext.js';
 import { MESSAGE_TYPES } from '../shared/messages.js';
 import { PHASES } from '../shared/constants.js';
 import Board from './Board.jsx';
+import PlayerList from './PlayerList.jsx';
 
 /**
  * Main game UI. Renders based on current game state from context.
@@ -74,6 +75,7 @@ export default function Game() {
       <h2>Game In Progress</h2>
       <button onClick={exitRoom}>Leave Room</button>
       <Board />
+      <PlayerList />
       {gameState.gameOver && (
         <div>
           <h3>Game Over</h3>

--- a/client/PlayerList.jsx
+++ b/client/PlayerList.jsx
@@ -1,0 +1,33 @@
+import React, { useContext } from 'react';
+import { GameStateContext } from './GameStateContext.js';
+
+/**
+ * Displays the list of players in seating order with indicators
+ * for the current President and Chancellor. Executed players are
+ * shown but marked as dead.
+ */
+export default function PlayerList() {
+  const { gameState } = useContext(GameStateContext);
+  const game = gameState.game;
+  if (!game) return null;
+
+  return (
+    <div>
+      <h3>Players</h3>
+      <ol>
+        {game.players.map((p, idx) => {
+          const isPresident = idx === game.presidentIndex;
+          const isChancellor = idx === game.chancellorIndex;
+          return (
+            <li key={p.id}>
+              {p.name}
+              {!p.alive && ' (dead)'}
+              {isPresident && ' - President'}
+              {isChancellor && ' - Chancellor'}
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- display list of players in seating order during game
- update TODO and agent docs with new PlayerList info

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684e009990d8832a9ec2ad9d10a979d9