### PR TITLE
Add voting and victory tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Jest test framework added with initial unit tests for utilities and
   game engine nomination rules.
 - First Presidential Candidate now chosen randomly (Rules: Setup step 4).
+- Added tests for vote majority, election tracker auto policy, and Hitler election victory.
 
 
 
@@ -244,7 +245,7 @@ UI reactivity | Partial | Basic board component added; nomination and vote resul
 Player list display | ✅ | PlayerList component shows seating order with President and Chancellor markers
 Socket message handling | ✅ | Client and server handle defined message types
 Rules compliance (RULES.md) | Partial | Most rules enforced; disconnecting players are treated as executions
-Automated tests | Partial | Jest added with initial unit tests; more coverage needed
+Automated tests | Partial | Coverage expanded with voting and victory tests; further power tests needed
 
 - Identified blockers to reach playtest:
 - Improve phase-specific UI

--- a/TODO.md
+++ b/TODO.md
@@ -40,9 +40,12 @@
 - Set up Jest with Babel configuration and added unit tests for `assignRoles`,
   `shuffleDeck` and Chancellor nomination eligibility.
 - First Presidential Candidate is now selected randomly when the game starts.
+- Added unit tests covering vote majority with dead players,
+  automatic policy enactment after three failed elections,
+  and Hitler election victory condition.
 
 ## Next Steps
 - Expand React UI components for each gameplay phase (policy draw, powers, prompts) to improve reactivity.
-- Add more unit tests covering voting logic, policy processing and presidential
+- Add more unit tests covering policy processing and presidential
   powers. Integrate tests with CI.
 - Improve UI styling for board and player list.

--- a/tests/gameEngine.test.js
+++ b/tests/gameEngine.test.js
@@ -1,5 +1,9 @@
-const { nominateChancellor, startGame } = require('../server/gameEngine.js');
-const { ROLE_DISTRIBUTION } = require('../shared/constants.js');
+const {
+  nominateChancellor,
+  startGame,
+  handleVote,
+} = require('../server/gameEngine.js');
+const { ROLE_DISTRIBUTION, PHASES, ROLES } = require('../shared/constants.js');
 
 function createRoom(playerCount) {
   const players = Array.from({ length: playerCount }, (_, i) => ({ id: `p${i}`, name: `P${i}` }));
@@ -25,5 +29,65 @@ describe('nominateChancellor eligibility', () => {
     state.presidentIndex = 1;
     const success = nominateChancellor(room, state.players[1].id, state.players[0].id);
     expect(success).toBe(true);
+  });
+});
+
+describe('handleVote', () => {
+  test('majority counts only alive players', () => {
+    const room = createRoom(5);
+    startGame(room);
+    const state = room.game;
+    state.presidentIndex = 0;
+    nominateChancellor(room, state.players[0].id, state.players[1].id);
+    // kill one player
+    state.players[4].alive = false;
+    handleVote(room, state.players[0].id, true);
+    handleVote(room, state.players[1].id, true);
+    handleVote(room, state.players[2].id, true);
+    const result = handleVote(room, state.players[3].id, false);
+    expect(result.passed).toBe(true);
+    expect(state.phase).toBe(PHASES.POLICY);
+  });
+
+  test('auto policy enacted after three failed elections', () => {
+    const room = createRoom(5);
+    startGame(room);
+    const state = room.game;
+    state.presidentIndex = 0;
+    // stack deck to know result
+    state.policyDeck = ['FASCIST'];
+    for (let i = 0; i < 3; i++) {
+      const president = state.players[state.presidentIndex];
+      const nominee = state.players[(state.presidentIndex + 1) % state.players.length];
+      nominateChancellor(room, president.id, nominee.id);
+      state.players
+        .filter((p) => p.alive)
+        .forEach((p) => handleVote(room, p.id, false));
+      if (i < 2) {
+        expect(state.failedElections).toBe(i + 1);
+        expect(state.phase).toBe(PHASES.NOMINATE);
+      }
+    }
+    expect(state.failedElections).toBe(0);
+    expect(state.enactedPolicies.fascist + state.enactedPolicies.liberal).toBe(1);
+  });
+
+  test('electing Hitler after three fascist policies ends game', () => {
+    const room = createRoom(5);
+    startGame(room);
+    const state = room.game;
+    state.presidentIndex = 0;
+    state.enactedPolicies.fascist = 3;
+    state.players[2].role = ROLES.HITLER;
+    nominateChancellor(room, state.players[0].id, state.players[2].id);
+    const alive = state.players.filter((p) => p.alive);
+    let result;
+    alive.forEach((p, idx) => {
+      result = handleVote(room, p.id, true);
+    });
+    expect(result.gameOver).toEqual({
+      winner: 'FASCISTS',
+      reason: 'HITLER_ELECTED',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for vote majority, election tracker auto policy, and Hitler win
- document new tests in TODO and AGENTS notes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e049c3590832aa05b147ae23b1563