### PR TITLE
Fix election tracker power handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,10 +265,9 @@ Win condition checks | ✅ | Liberal/Fascist policy totals and Hitler conditions
 Game state broadcast & sync | Partial | Some state changes still missing dedicated events
 UI reactivity | Partial | React components display basic prompts but lack polish
 Socket message handling | ✅ | Client and server support defined message types
-Rules compliance (RULES.md) | Partial | Auto policy from the election tracker incorrectly grants powers
+Rules compliance (RULES.md) | ✅ | Auto policy from the election tracker now ignores powers
 
 - Current blockers:
-  - Fix auto-policy logic so no power is granted when a random policy is enacted
   - Create phase-oriented UI components for better reactivity
   - Expand test coverage for powers and win conditions
   - Ensure every state change emits updates to prevent desync

--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,8 @@
 - Added vote result display showing each player's Ja!/Nein choice.
 - Implemented board UI showing enacted policies and election tracker progress.
 - Added PlayerList component showing seating order with President and Chancellor markers.
+- Fixed auto policy logic so election tracker enactments never grant
+  presidential powers.
 
 ### New in this wave
 - Set up Jest with Babel configuration and added unit tests for `assignRoles`,
@@ -45,8 +47,6 @@
   and Hitler election victory condition.
 
 ## Next Steps
-- Correct auto policy logic so election tracker enactments never grant
-  presidential powers.
 - Ensure every game state change emits a room update to keep clients
   in sync.
 - Expand React UI components for each gameplay phase (policy draw, powers, prompts) to improve reactivity.

--- a/server/gameEngine.js
+++ b/server/gameEngine.js
@@ -247,7 +247,7 @@ function handleVote(room, playerId, vote) {
       state.failedElections += 1;
       if (state.failedElections >= 3) {
         const autoPolicy = drawPolicies(state, 1)[0];
-        autoResult = processPolicy(room, autoPolicy);
+        autoResult = processPolicy(room, autoPolicy, false);
         state.failedElections = 0;
         state.lastPresidentId = null;
         state.lastChancellorId = null;
@@ -270,8 +270,11 @@ function handleVote(room, playerId, vote) {
 
 /**
  * Processes a selected policy.
+ * @param {object} room Room containing the game state
+ * @param {string} policy Policy to enact
+ * @param {boolean} grantPower Whether a fascist power should trigger
  */
-function processPolicy(room, policy) {
+function processPolicy(room, policy, grantPower = true) {
   const state = room.game;
   if (!state) return null;
 
@@ -288,7 +291,7 @@ function processPolicy(room, policy) {
   state.chancellorIndex = null;
 
   if (!victory) {
-    if (policy === 'FASCIST') {
+    if (policy === 'FASCIST' && grantPower) {
       const power = getGrantedPower(state);
       if (power && power !== POWERS.NONE) {
         state.pendingPower = power;
@@ -398,7 +401,7 @@ function handleVetoDecision(room, playerId, accept) {
     let autoResult = null;
     if (state.failedElections >= 3) {
       const autoPolicy = drawPolicies(state, 1)[0];
-      autoResult = processPolicy(room, autoPolicy);
+      autoResult = processPolicy(room, autoPolicy, false);
       state.failedElections = 0;
       state.lastPresidentId = null;
       state.lastChancellorId = null;

--- a/tests/gameEngine.test.js
+++ b/tests/gameEngine.test.js
@@ -72,6 +72,24 @@ describe('handleVote', () => {
     expect(state.enactedPolicies.fascist + state.enactedPolicies.liberal).toBe(1);
   });
 
+  test('auto policy from election tracker grants no power', () => {
+    const room = createRoom(7);
+    startGame(room);
+    const state = room.game;
+    state.presidentIndex = 0;
+    state.policyDeck = ['FASCIST'];
+    for (let i = 0; i < 3; i++) {
+      const president = state.players[state.presidentIndex];
+      const nominee = state.players[(state.presidentIndex + 1) % state.players.length];
+      nominateChancellor(room, president.id, nominee.id);
+      state.players
+        .filter((p) => p.alive)
+        .forEach((p) => handleVote(room, p.id, false));
+    }
+    expect(state.pendingPower).toBe(null);
+    expect(state.phase).toBe(PHASES.NOMINATE);
+  });
+
   test('electing Hitler after three fascist policies ends game', () => {
     const room = createRoom(5);
     startGame(room);


### PR DESCRIPTION
## Summary
- ensure automatic policies from failed elections don't grant presidential powers
- add test confirming auto enactment skips powers
- document work in TODO and progress guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e064ebf94832aa16ab377a5a1b05f