### PR TITLE
Improve disconnect handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Executed player restrictions enforced. Dead players cannot vote or hold office and presidency skips them. UI still needs cues.
 - Lobby now displays joined players and room code. Only the host may start the game once five or more players have joined. Clients stay in the lobby until the `GAME_START` message arrives.
 - Players may leave a room before the game starts via `LEAVE_ROOM`. Disconnecting during a game now marks that player as executed and ends the game if Hitler disconnects.
+- Disconnects are handled inside the game engine. If a disconnecting player was part of the active government, the election fails and the tracker advances. No role information is revealed unless Hitler was executed.
 - Auto policy results from the Election Tracker are now broadcast to all players to maintain sync.
 - Client tracks current nomination and displays vote results to improve transparency.
 - Basic board UI added showing policy tracks and election tracker progress.

--- a/TODO.md
+++ b/TODO.md
@@ -39,6 +39,12 @@
   presidential powers.
 
 ### New in this wave
+- Refactored disconnect handling into the game engine so disconnecting players
+  are treated as executions without leaking roles. If the disconnecting player
+  was part of the government the election now fails and advances the tracker.
+- Added unit tests covering disconnect outcomes and Hitler disconnect victory.
+
+### Previous wave
 - Set up Jest with Babel configuration and added unit tests for `assignRoles`,
   `shuffleDeck` and Chancellor nomination eligibility.
 - First Presidential Candidate is now selected randomly when the game starts.


### PR DESCRIPTION
## Summary
- centralize disconnect logic in game engine
- server uses new handler and no longer removes players from room list
- add unit tests for disconnect logic
- document behavior in AGENTS guidance
- update TODOs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e0759a570832a8aa16ac62876662f