### PR TITLE
Improve board and player list styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Add simple log on server to trace game state changes.
 - Use mock players for testing (e.g., 5 bots).
 - Keep all UI mobile-friendly from the start.
+- Tailwind CSS is currently loaded via CDN in `client/index.html` until a build step is added.
 - Chancellor term limit logic now enforced in `gameEngine.js`.
 - Chancellor term limit logic now enforced in `gameEngine.js`.
 - Investigate Loyalty implemented; remember to send POWER_PROMPT only to the acting President and POWER_RESULT only to them.

--- a/TODO.md
+++ b/TODO.md
@@ -11,10 +11,11 @@
 - Action log and basic AI tips
 - Jest test suite covering utilities, core game logic, and tips engine
 - Room updates broadcast after every state change
+- Improved styling for the board and player list
 
 ## 🔨 In Progress
 - Expand test coverage for remaining edge cases and powers
-- Improve styling for the board and player list
+- Polish layout for main game UI components
 
 ## 🧠 Needs Design Decision
 - Confirmation or restrictions when players attempt to leave mid-game

--- a/client/Board.jsx
+++ b/client/Board.jsx
@@ -15,13 +15,47 @@ export default function Board() {
     game.chancellorIndex != null ? game.players?.[game.chancellorIndex] : null;
 
   return (
-    <div>
-      <h3>Board</h3>
-      <p>Liberal Policies: {liberal} / 5</p>
-      <p>Fascist Policies: {fascist} / 6</p>
-      <p>Election Tracker: {tracker} / 3</p>
-      {president && <p>President: {president.name}</p>}
-      {chancellor && <p>Chancellor: {chancellor.name}</p>}
+    <div className="board bg-gray-100 p-4 rounded shadow max-w-md mx-auto mb-4">
+      <h3 className="text-xl font-bold mb-2">Board</h3>
+
+      <div className="mb-3">
+        <p className="font-semibold">Liberal Policies</p>
+        <div className="flex space-x-1 mt-1">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className={`w-6 h-6 border ${i < liberal ? 'bg-blue-500' : 'bg-gray-200'}`}
+            ></div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-3">
+        <p className="font-semibold">Fascist Policies</p>
+        <div className="flex space-x-1 mt-1">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className={`w-6 h-6 border ${i < fascist ? 'bg-red-500' : 'bg-gray-200'}`}
+            ></div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-3">
+        <p className="font-semibold">Election Tracker</p>
+        <div className="flex space-x-1 mt-1">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className={`w-6 h-6 border ${i < tracker ? 'bg-yellow-500' : 'bg-gray-200'}`}
+            ></div>
+          ))}
+        </div>
+      </div>
+
+      {president && <p className="italic">President: {president.name}</p>}
+      {chancellor && <p className="italic">Chancellor: {chancellor.name}</p>}
     </div>
   );
 }

--- a/client/PlayerList.jsx
+++ b/client/PlayerList.jsx
@@ -12,18 +12,26 @@ export default function PlayerList() {
   if (!game) return null;
 
   return (
-    <div>
-      <h3>Players</h3>
-      <ol>
+    <div className="player-list bg-white p-4 rounded shadow max-w-md mx-auto mb-4">
+      <h3 className="text-xl font-bold mb-2">Players</h3>
+      <ol className="space-y-1">
         {game.players.map((p, idx) => {
           const isPresident = idx === game.presidentIndex;
           const isChancellor = idx === game.chancellorIndex;
+          const deadStyles = !p.alive ? 'line-through text-gray-500' : '';
           return (
-            <li key={p.id}>
-              {p.name}
-              {!p.alive && ' (dead)'}
-              {isPresident && ' - President'}
-              {isChancellor && ' - Chancellor'}
+            <li key={p.id} className={`flex items-center ${deadStyles}`}>
+              <span className="flex-1">{p.name}</span>
+              {isPresident && (
+                <span className="ml-2 text-blue-600" title="President">
+                  👑
+                </span>
+              )}
+              {isChancellor && (
+                <span className="ml-2 text-green-600" title="Chancellor">
+                  ⭐
+                </span>
+              )}
             </li>
           );
         })}

--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Secret Hitler</title>
   <!-- TODO: link to bundled JS when build process is set up -->
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body>
   <!-- Root element for React rendering -->


### PR DESCRIPTION
## Summary
- style board with policy tracker visuals
- style player list with status icons and dead player cues
- load Tailwind via CDN and note this in AGENTS instructions
- update TODO list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5bbcd280832a9fa1d437ba21cd1e