### PR TITLE
Add confirmation before leaving mid‑game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Lobby now displays joined players and room code. Only the host may start the game once five or more players have joined. Clients stay in the lobby until the `GAME_START` message arrives.
 - Players may leave a room before the game starts via `LEAVE_ROOM`. Disconnecting during a game now marks that player as executed and ends the game if Hitler disconnects.
 - Leaving via `LEAVE_ROOM` after the game has begun is treated the same as a disconnect and executes that player.
+- The client now prompts for confirmation before sending `LEAVE_ROOM` during an active game.
 - Disconnects are handled inside the game engine. If a disconnecting player was part of the active government, the election fails and the tracker advances. No role information is revealed unless Hitler was executed.
 - Auto policy results from the Election Tracker are now broadcast to all players to maintain sync.
 - Client tracks current nomination and displays vote results to improve transparency.

--- a/TODO.md
+++ b/TODO.md
@@ -11,13 +11,13 @@
 - Action log and basic AI tips
 - Jest test suite covering utilities, core game logic, and tips engine
 - Room updates broadcast after every state change
+- Confirmation prompt when a player attempts to leave mid-game
 
 ## 🔨 In Progress
 - Expand test coverage for remaining edge cases and powers
 - Improve styling for the board and player list
 
 ## 🧠 Needs Design Decision
-- Confirmation or restrictions when players attempt to leave mid-game
 - Long-term room persistence for multi-server deployment
 
 ## 🕳️ Missing / Skipped Logic

--- a/client/GameStateContext.js
+++ b/client/GameStateContext.js
@@ -115,6 +115,15 @@ export default function GameStateProvider({ children }) {
   }, []);
 
   const leaveRoom = (roomCode) => {
+    if (
+      gameState?.game &&
+      gameState.game.phase !== PHASES.GAME_OVER &&
+      !window.confirm(
+        'Leaving now counts as a resignation and may end the game. Are you sure?'
+      )
+    ) {
+      return;
+    }
     if (socket) {
       socket.emit(MESSAGE_TYPES.LEAVE_ROOM, { roomCode });
     }


### PR DESCRIPTION
## Summary
- prompt players before leaving an active game
- document the new confirmation behavior
- record completed task in TODO list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5bdcdf34832a9aa7f3bfe8a3109c