### PR TITLE
Implement leave confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ Use Tailwind CSS to ensure responsive layout, and structure all UI elements in a
 - Executed player restrictions enforced. Dead players cannot vote or hold office and presidency skips them. UI still needs cues.
 - Lobby now displays joined players and room code. Only the host may start the game once five or more players have joined. Clients stay in the lobby until the `GAME_START` message arrives.
 - Players may leave a room before the game starts via `LEAVE_ROOM`. Disconnecting during a game now marks that player as executed and ends the game if Hitler disconnects.
-- Leaving via `LEAVE_ROOM` after the game has begun is treated the same as a disconnect and executes that player.
+- Leaving via `LEAVE_ROOM` after the game has begun is treated the same as a disconnect and executes that player. The client now prompts for confirmation before leaving mid-game to avoid accidental exits.
 - Disconnects are handled inside the game engine. If a disconnecting player was part of the active government, the election fails and the tracker advances. No role information is revealed unless Hitler was executed.
 - Auto policy results from the Election Tracker are now broadcast to all players to maintain sync.
 - Client tracks current nomination and displays vote results to improve transparency.

--- a/TODO.md
+++ b/TODO.md
@@ -13,13 +13,13 @@
 - Room updates broadcast after every state change
 - Expand test coverage for remaining edge cases and powers
 - Improved styling for the board and player list
+- Confirmation prompt when leaving a game in progress
 
 ## 🔨 In Progress
 - Polish layout for main game UI components
 
 
 ## 🧠 Needs Design Decision
-- Confirmation or restrictions when players attempt to leave mid-game
 - Long-term room persistence for multi-server deployment
 
 ## 🕳️ Missing / Skipped Logic

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { GameStateContext } from './GameStateContext.js';
+import { PHASES } from '../shared/constants.js';
 import Board from './Board.jsx';
 import PlayerList from './PlayerList.jsx';
 import ActionLog from './ActionLog.jsx';
@@ -32,6 +33,15 @@ export default function Game() {
   const roomCode = gameState?.code || gameState?.roomCode;
 
   const exitRoom = () => {
+    if (
+      gameState?.game &&
+      gameState.game.phase !== PHASES.GAME_OVER &&
+      !window.confirm(
+        'Leaving will mark you as executed and may end the game. Are you sure?'
+      )
+    ) {
+      return;
+    }
     if (gameState?.code) {
       leaveRoom(gameState.code);
     }


### PR DESCRIPTION
## Summary
- prompt players before leaving a game in progress
- record completion of this task in TODO
- note confirmation prompt in AGENTS instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5d2d62e0832a99dbf0b40af79344