### PR TITLE
Add execution and game over overlays

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 - Room updates broadcast after every state change
 - Expand test coverage for remaining edge cases and powers
 - Improved styling for the board and player list
+- Additional UX cues for executed players and game over screens
 
 ## 🔨 In Progress
 - Polish layout for main game UI components
@@ -24,7 +25,6 @@
 
 ## 🕳️ Missing / Skipped Logic
 - Reconnection support for players who refresh or temporarily lose connection
-- Additional UX cues for executed players and game over screens
 
 ## ⏳ Low Priority / Post-MVP
 - Enhanced tips engine tracking past actions for better suggestions

--- a/client/ExecutedOverlay.jsx
+++ b/client/ExecutedOverlay.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * Overlay shown to players that have been executed.
+ * Provides a persistent reminder they may only observe.
+ */
+export default function ExecutedOverlay() {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center text-white pointer-events-none z-40">
+      <div className="bg-red-900 p-4 rounded shadow-lg">
+        <p>You have been executed and may not act.</p>
+      </div>
+    </div>
+  );
+}

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -9,6 +9,8 @@ import VotePanel from './VotePanel.jsx';
 import PolicyHand from './PolicyHand.jsx';
 import VetoPrompt from './VetoPrompt.jsx';
 import PowerPanel from './PowerPanel.jsx';
+import ExecutedOverlay from './ExecutedOverlay.jsx';
+import GameOverScreen from './GameOverScreen.jsx';
 
 /**
  * Main game UI. Renders based on current game state from context.
@@ -44,13 +46,6 @@ export default function Game() {
       <button onClick={exitRoom}>Leave Room</button>
       <Board />
       <PlayerList />
-      {gameState.gameOver && (
-        <div>
-          <h3>Game Over</h3>
-          <p>Winner: {gameState.gameOver.winner}</p>
-          <p>Reason: {gameState.gameOver.reason}</p>
-        </div>
-      )}
       {role && <p>Your role: {role}</p>}
       {roleInfo && roleInfo.fascists && roleInfo.fascists.length > 0 && (
         <div>
@@ -66,7 +61,7 @@ export default function Game() {
         <p>Hitler is {roleInfo.hitler.name}</p>
       )}
 
-      {me && !me.alive && <p>You have been executed and may not act.</p>}
+      {me && !me.alive && !gameState.gameOver && <ExecutedOverlay />}
 
       {nomination && (
         <p>
@@ -109,9 +104,6 @@ export default function Game() {
       {powerResult && powerResult.power === 'EXECUTION' && (
         <div>
           <p>{powerResult.targetName} has been executed.</p>
-          {powerResult.gameOver && (
-            <p>Game Over - {powerResult.gameOver.winner} win: {powerResult.gameOver.reason}</p>
-          )}
         </div>
       )}
 
@@ -133,6 +125,8 @@ export default function Game() {
 
       <Tips />
       <ActionLog />
+
+      {gameState.gameOver && <GameOverScreen />}
 
       <pre>{JSON.stringify(gameState, null, 2)}</pre>
     </div>

--- a/client/GameOverScreen.jsx
+++ b/client/GameOverScreen.jsx
@@ -1,0 +1,39 @@
+import React, { useContext } from 'react';
+import { GameStateContext } from './GameStateContext.js';
+
+/**
+ * Full-screen overlay shown when the game ends.
+ * Displays winner, reason, and reveals all player roles.
+ */
+export default function GameOverScreen() {
+  const { gameState, leaveRoom } = useContext(GameStateContext);
+  const result = gameState.gameOver;
+  const players = gameState.game?.players || [];
+
+  if (!result) return null;
+
+  const exit = () => {
+    if (gameState.code) {
+      leaveRoom(gameState.code);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center text-white z-50">
+      <div className="bg-gray-800 p-6 rounded shadow-lg max-w-md text-center">
+        <h2 className="text-2xl font-bold mb-4">Game Over</h2>
+        <p className="mb-2">Winner: {result.winner}</p>
+        <p className="mb-4">Reason: {result.reason}</p>
+        <h3 className="text-xl font-semibold mb-2">Final Roles</h3>
+        <ul className="mb-4">
+          {players.map((p) => (
+            <li key={p.id} className={!p.alive ? 'line-through text-gray-400' : ''}>
+              {p.name} - {p.role}
+            </li>
+          ))}
+        </ul>
+        <button onClick={exit} className="bg-white text-black px-4 py-2 rounded">Exit Room</button>
+      </div>
+    </div>
+  );
+}

--- a/client/PlayerList.jsx
+++ b/client/PlayerList.jsx
@@ -22,6 +22,9 @@ export default function PlayerList() {
           return (
             <li key={p.id} className={`flex items-center ${deadStyles}`}>
               <span className="flex-1">{p.name}</span>
+              {!p.alive && (
+                <span className="ml-2 text-gray-600" title="Executed">☠️</span>
+              )}
               {isPresident && (
                 <span className="ml-2 text-blue-600" title="President">
                   👑


### PR DESCRIPTION
## Summary
- show skull icon for executed players in PlayerList
- overlay for executed players
- game over overlay with final roles
- use overlays in Game component
- update TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5d6b24ac832a923186057505c88b