### PR TITLE
Implement per-room chat with bots

### DIFF
--- a/client/ChatBox.jsx
+++ b/client/ChatBox.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useContext, useRef, useEffect } from 'react';
+import { GameStateContext } from './GameStateContext.js';
+
+export default function ChatBox() {
+  const { chatLog, sendChat, gameState } = useContext(GameStateContext);
+  const [text, setText] = useState('');
+  const endRef = useRef(null);
+  const roomCode = gameState.code || gameState.roomCode;
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [chatLog]);
+
+  const submit = () => {
+    const msg = text.trim();
+    if (!msg) return;
+    sendChat(roomCode, msg, 'global');
+    setText('');
+  };
+
+  return (
+    <div className="bg-white p-4 rounded shadow mb-4 text-sm">
+      <div className="h-32 overflow-y-auto mb-2 border p-1">
+        {chatLog.map((m, idx) => (
+          <div key={idx}>
+            <strong>{m.from}:</strong> {m.message}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <div className="flex">
+        <input
+          className="flex-1 border px-2"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submit();
+          }}
+        />
+        <button
+          onClick={submit}
+          className="bg-blue-600 text-white px-2 ml-1 rounded"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/Game.jsx
+++ b/client/Game.jsx
@@ -12,6 +12,7 @@ import VetoPrompt from './VetoPrompt.jsx';
 import PowerPanel from './PowerPanel.jsx';
 import ExecutedOverlay from './ExecutedOverlay.jsx';
 import GameOverScreen from './GameOverScreen.jsx';
+import ChatBox from './ChatBox.jsx';
 
 /**
  * Main game UI. Renders based on current game state from context.
@@ -152,6 +153,8 @@ export default function Game() {
         <Tips />
         <ActionLog />
       </div>
+
+      <ChatBox />
 
       {gameState.gameOver && <GameOverScreen />}
 

--- a/client/GameStateContext.js
+++ b/client/GameStateContext.js
@@ -19,6 +19,7 @@ export default function GameStateProvider({ children }) {
   const [powerResult, setPowerResult] = useState(null);
   const [playerId, setPlayerId] = useState(null);
   const [nomination, setNomination] = useState(null);
+  const [chatLog, setChatLog] = useState([]);
 
   const resetState = () => {
     setGameState({});
@@ -29,6 +30,7 @@ export default function GameStateProvider({ children }) {
     setPowerPrompt(null);
     setPowerResult(null);
     setNomination(null);
+    setChatLog([]);
   };
 
   useEffect(() => {
@@ -111,6 +113,10 @@ export default function GameStateProvider({ children }) {
       setPolicyPrompt(null);
     });
 
+    sock.on(MESSAGE_TYPES.CHAT_RECEIVE, (msg) => {
+      setChatLog((prev) => [...prev, msg]);
+    });
+
     sock.on(MESSAGE_TYPES.GAME_OVER, (result) => {
       setGameState((prev) => ({
         ...prev,
@@ -141,6 +147,12 @@ export default function GameStateProvider({ children }) {
     resetState();
   };
 
+  const sendChat = (roomCode, message, to = 'global') => {
+    if (socket) {
+      socket.emit(MESSAGE_TYPES.CHAT_SEND, { roomCode, message, to });
+    }
+  };
+
   return (
     <GameStateContext.Provider
       value={{
@@ -154,6 +166,8 @@ export default function GameStateProvider({ children }) {
         playerId,
         nomination,
         vetoPrompt,
+        chatLog,
+        sendChat,
         leaveRoom,
       }}
     >

--- a/server/bots/BotEngine.js
+++ b/server/bots/BotEngine.js
@@ -15,6 +15,9 @@ function createBot(role, name) {
     trustDecayRate: clamp(0, 1, 0.2 + (Math.random() - 0.5) * 0.2),
   };
 
+  const tones = ['cautious', 'aggressive', 'neutral'];
+  const tone = tones[Math.floor(Math.random() * tones.length)];
+
   const memory = {
     votingHistory: [],
     enactedPolicies: { liberal: 0, fascist: 0 },
@@ -104,8 +107,22 @@ function createBot(role, name) {
     return target.id;
   }
 
-  function say() {
-    return null;
+  function say(context = {}) {
+    const lines = [];
+    if (context.event === 'nomination' && context.nomineeName) {
+      if (tone === 'cautious') lines.push('Hmm… interesting nomination.');
+      if (tone === 'aggressive') lines.push(`Don't trust ${context.nomineeName} at all.`);
+      lines.push(`Good luck, ${context.nomineeName}.`);
+    }
+    if (context.event === 'voteResult') {
+      if (context.passed) lines.push('That was a bold play.');
+      else lines.push('Looks like that government failed.');
+    }
+    if (context.event === 'policy') {
+      lines.push('Let\'s keep moving.');
+    }
+    if (lines.length === 0) return null;
+    return lines[Math.floor(Math.random() * lines.length)];
   }
 
   return {
@@ -113,6 +130,7 @@ function createBot(role, name) {
     name,
     behavior,
     memory,
+    tone,
     voteOnGovernment,
     nominateChancellor,
     choosePolicy,

--- a/server/chat.js
+++ b/server/chat.js
@@ -1,0 +1,44 @@
+const { PHASES } = require('../shared/constants.js');
+
+function sanitizeMessage(str) {
+  if (!str) return '';
+  return String(str).replace(/<[^>]*>/g, '').replace(/[<>]/g, '');
+}
+
+function determineRecipients(room, to) {
+  const game = room.game;
+  const recipients = [];
+  if (!game) return recipients;
+  if (to === 'global' || !to) {
+    room.players.forEach(p => {
+      if (p.socketId) recipients.push(p.socketId);
+    });
+  } else if (to === 'presidentOnly') {
+    const pres = game.players[game.presidentIndex];
+    if (pres && pres.socketId) recipients.push(pres.socketId);
+  } else if (to === 'chancellorOnly') {
+    const chan = game.players[game.chancellorIndex];
+    if (chan && chan.socketId) recipients.push(chan.socketId);
+  } else if (Array.isArray(to)) {
+    to.forEach(id => {
+      const target = room.players.find(p => p.id === id);
+      if (target && target.socketId) recipients.push(target.socketId);
+    });
+  }
+  return recipients;
+}
+
+function prepareChat(room, fromId, text, to = 'global') {
+  if (!room || !room.game) return null;
+  const fromPlayer = room.players.find(p => p.id === fromId);
+  if (!fromPlayer) return null;
+  const msg = sanitizeMessage(text);
+  const entry = { from: fromPlayer.name, message: msg, to, timestamp: Date.now() };
+  room.game.chatLog = room.game.chatLog || [];
+  room.game.chatLog.push(entry);
+  const socketIds = determineRecipients(room, to);
+  const visibility = to === 'global' ? 'global' : Array.isArray(to) ? 'private' : 'limited';
+  return { entry, socketIds, visibility };
+}
+
+module.exports = { sanitizeMessage, prepareChat };

--- a/server/gameEngine.js
+++ b/server/gameEngine.js
@@ -121,6 +121,7 @@ function startGame(room) {
     discardPile: [],
     enactedPolicies: { liberal: 0, fascist: 0 },
     history: [],
+    chatLog: [],
     settings: { playerCount: room.players.length },
     lastPresidentId: null,
     lastChancellorId: null,

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const roomManager = require('./roomManager.js');
 const gameEngine = require('./gameEngine.js');
 const { MESSAGE_TYPES } = require('../shared/messages.js');
 const { PHASES, POWERS, ROLES } = require('../shared/constants.js');
+const { prepareChat } = require('./chat.js');
 
 /**
  * Initializes express and socket.io server.
@@ -374,6 +375,22 @@ io.on('connection', (socket) => {
       }
         emitRoomUpdate(roomCode, room);
     }
+  });
+
+  socket.on(MESSAGE_TYPES.CHAT_SEND, ({ roomCode, message, to }) => {
+    const room = roomManager.getRoomByCode(roomCode);
+    if (!room || !room.game) return;
+    const playerId = getPlayerId(room, socket.id);
+    if (!playerId) return;
+    const result = prepareChat(room, playerId, message, to);
+    if (!result) return;
+    result.socketIds.forEach((sid) => {
+      io.to(sid).emit(MESSAGE_TYPES.CHAT_RECEIVE, {
+        from: result.entry.from,
+        message: result.entry.message,
+        visibility: result.visibility,
+      });
+    });
   });
 
   // NOTE: add new game event handlers as features expand

--- a/shared/messages.js
+++ b/shared/messages.js
@@ -27,6 +27,8 @@ const MESSAGE_TYPES = Object.freeze({
   RECONNECT: 'RECONNECT',
   ASSIGN_PLAYER_ID: 'ASSIGN_PLAYER_ID',
   GAME_OVER: 'GAME_OVER',
+  CHAT_SEND: 'chat:send',
+  CHAT_RECEIVE: 'chat:receive',
 });
 
 module.exports = {

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -1,0 +1,31 @@
+const { prepareChat, sanitizeMessage } = require('../server/chat.js');
+
+function createRoom() {
+  return {
+    players: [
+      { id: 'a', name: 'A', socketId: '1' },
+      { id: 'b', name: 'B', socketId: '2' },
+    ],
+    game: {
+      players: [
+        { id: 'a', name: 'A', socketId: '1' },
+        { id: 'b', name: 'B', socketId: '2' },
+      ],
+      presidentIndex: 0,
+      chancellorIndex: 1,
+      chatLog: [],
+    },
+  };
+}
+
+test('sanitizeMessage strips html tags', () => {
+  expect(sanitizeMessage('<b>hi</b>')).toBe('hi');
+});
+
+test('prepareChat records log and targets president', () => {
+  const room = createRoom();
+  const result = prepareChat(room, 'a', 'hello', 'presidentOnly');
+  expect(room.game.chatLog).toHaveLength(1);
+  expect(result.socketIds).toEqual(['1']);
+  expect(result.visibility).toBe('limited');
+});


### PR DESCRIPTION
## Summary
- add chat message types
- implement chat helpers for routing and sanitizing
- append chat log to game state
- handle CHAT_SEND events on the server
- track chat on the client and send messages
- show chat box in game UI
- expand bot engine with tone and say() responses
- test chat utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea24f06b8832a81777dc38f88cdf6