### PR TITLE
Add portrait fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 *.log
+public/assets/portraits/*.png

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@
 - Reconnection support for players who refresh or temporarily lose connection
 - Polish layout for main game UI components
 - Developer debug toggle for viewing game state
+- Player portrait system with role-based reveal
 
 ## ✅ Completed (continued)
 - Basic phase state machine added for switching between Lobby and Game views

--- a/client/Lobby.jsx
+++ b/client/Lobby.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { GameStateContext } from './GameStateContext.js';
 import { MESSAGE_TYPES } from '../shared/messages.js';
+import { PORTRAITS } from '../shared/constants.js';
 
 /**
  * Lobby view for entering a name and room code.
@@ -10,13 +11,16 @@ export default function Lobby() {
   const { socket, gameState, playerId, leaveRoom } = useContext(GameStateContext);
   const [name, setName] = useState('');
   const [roomCode, setRoomCode] = useState('');
+  const [portrait, setPortrait] = useState(PORTRAITS[0]);
 
   const createRoom = () => {
-    if (socket) socket.emit(MESSAGE_TYPES.CREATE_ROOM, { name, playerId });
+    if (socket)
+      socket.emit(MESSAGE_TYPES.CREATE_ROOM, { name, portrait, playerId });
   };
 
   const joinRoom = () => {
-    if (socket) socket.emit(MESSAGE_TYPES.JOIN_ROOM, { name, roomCode, playerId });
+    if (socket)
+      socket.emit(MESSAGE_TYPES.JOIN_ROOM, { name, roomCode, portrait, playerId });
   };
 
   const startGame = () => {
@@ -44,6 +48,17 @@ export default function Lobby() {
         value={name}
         onChange={(e) => setName(e.target.value)}
       />
+      <select
+        value={portrait}
+        onChange={(e) => setPortrait(e.target.value)}
+        className="ml-2"
+      >
+        {PORTRAITS.map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
       <input
         type="text"
         placeholder="Room code"

--- a/client/PlayerList.jsx
+++ b/client/PlayerList.jsx
@@ -1,13 +1,31 @@
 import React, { useContext } from 'react';
 import { GameStateContext } from './GameStateContext.js';
 
+function roleVariant(role) {
+  if (role === 'FASCIST') return 'fascist';
+  if (role === 'HITLER') return 'hitler';
+  return 'neutral';
+}
+
+const FALLBACK_SRC =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAiUlEQVR4nO3OMQ0EIRRFUWYLNAwGUECJBJKxgCssTE2JAhoQgAFsTLEOhiU/2dwj4L2rFAAAAAAAAAAAf8R7X2ttrYUQpFte6b1ba40xYwzplldijEoprfWcU7plgXMu57xv/7Nv+uu6rpTS7peN7vs+jkO6YsF5ntIJa0op0gkAAAAAAAAAfu4B2AcZy2t1/7sAAAAASUVORK5CYII=';
+
+function getPortraitForViewer(player, viewerId) {
+  if (!player.portrait) return null;
+  const variant =
+    player.id === viewerId || player.isRevealedTo.includes(viewerId)
+      ? roleVariant(player.role)
+      : 'neutral';
+  return `/assets/portraits/${player.portrait}_${variant}.png`;
+}
+
 /**
  * Displays the list of players in seating order with indicators
  * for the current President and Chancellor. Executed players are
  * shown but marked as dead.
  */
 export default function PlayerList() {
-  const { gameState } = useContext(GameStateContext);
+  const { gameState, playerId } = useContext(GameStateContext);
   const game = gameState.game;
   if (!game) return null;
 
@@ -19,8 +37,17 @@ export default function PlayerList() {
           const isPresident = idx === game.presidentIndex;
           const isChancellor = idx === game.chancellorIndex;
           const deadStyles = !p.alive ? 'line-through text-gray-500' : '';
+          const src = getPortraitForViewer(p, playerId);
           return (
             <li key={p.id} className={`flex items-center ${deadStyles}`}>
+              <img
+                src={src || FALLBACK_SRC}
+                alt=""
+                className="w-8 h-8 mr-2"
+                onError={(e) => {
+                  e.currentTarget.src = FALLBACK_SRC;
+                }}
+              />
               <span className="flex-1">{p.name}</span>
               {!p.alive && (
                 <span className="ml-2 text-gray-600" title="Executed">☠️</span>

--- a/server/bots/BotManager.js
+++ b/server/bots/BotManager.js
@@ -1,13 +1,21 @@
 "use strict";
 
-const { ROLES } = require("../../shared/constants.js");
+const { ROLES, PORTRAITS } = require("../../shared/constants.js");
 const { createBot } = require("./BotEngine.js");
 
 const botsByRoom = {};
 
 function addBotToRoom(room, role, name) {
   const bot = createBot(role, name);
-  room.players.push({ id: name, name, role, socketId: null });
+  const portrait = PORTRAITS[Math.floor(Math.random() * PORTRAITS.length)];
+  room.players.push({
+    id: name,
+    name,
+    role,
+    socketId: null,
+    portrait,
+    isBot: true,
+  });
   if (!botsByRoom[room.code]) botsByRoom[room.code] = [];
   botsByRoom[room.code].push(bot);
   return bot;

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -84,10 +84,14 @@ const ROLE_DISTRIBUTION = {
   10: { liberals: 6, fascists: 3, hitler: 1 },
 };
 
+// Available portrait identifiers
+const PORTRAITS = ['squirrel', 'robot', 'wizard', 'frog'];
+
 module.exports = {
   ROLES,
   PHASES,
   POWERS,
   FASCIST_POWERS,
   ROLE_DISTRIBUTION,
+  PORTRAITS,
 };


### PR DESCRIPTION
## Summary
- drop placeholder portrait images
- ignore portrait PNG files in git
- handle missing portraits client-side with a built-in fallback image

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ea5935c3c832ab6c669b8f4209233