### PR TITLE
Add portrait support with role reveal handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules/
 .env
 *.log
-public/
+public/*
+!public/assets/
+public/assets/*
+!public/assets/portraits/

--- a/client/Lobby.jsx
+++ b/client/Lobby.jsx
@@ -1,6 +1,18 @@
 import React, { useState, useContext } from 'react';
 import { GameStateContext } from './GameStateContext.js';
 import { MESSAGE_TYPES } from '../shared/messages.js';
+import Portrait from './components/Portrait.jsx';
+
+const availablePortraits = [
+  'owl',
+  'fox',
+  'robot',
+  'pirate',
+  'alien',
+  'witch',
+  'cat',
+  'deer',
+];
 
 /**
  * Lobby view for entering a name and room code.
@@ -10,13 +22,15 @@ export default function Lobby() {
   const { socket, gameState, playerId, leaveRoom } = useContext(GameStateContext);
   const [name, setName] = useState('');
   const [roomCode, setRoomCode] = useState('');
+  const [portrait, setPortrait] = useState(availablePortraits[0]);
 
   const createRoom = () => {
-    if (socket) socket.emit(MESSAGE_TYPES.CREATE_ROOM, { name, playerId });
+    if (socket) socket.emit(MESSAGE_TYPES.CREATE_ROOM, { name, playerId, portrait });
   };
 
   const joinRoom = () => {
-    if (socket) socket.emit(MESSAGE_TYPES.JOIN_ROOM, { name, roomCode, playerId });
+    if (socket)
+      socket.emit(MESSAGE_TYPES.JOIN_ROOM, { name, roomCode, playerId, portrait });
   };
 
   const startGame = () => {
@@ -37,6 +51,19 @@ export default function Lobby() {
   return (
     <div>
       <h1>Secret Hitler</h1>
+      <div className="grid grid-cols-4 gap-2 mb-2">
+        {availablePortraits.map((pId) => (
+          <div
+            key={pId}
+            onClick={() => setPortrait(pId)}
+            className={
+              'cursor-pointer border ' + (portrait === pId ? 'border-blue-500' : 'border-transparent')
+            }
+          >
+            <Portrait portraitId={pId} variant="neutral" />
+          </div>
+        ))}
+      </div>
       {joined && <p>Room Code: {gameState.code}</p>}
       <input
         type="text"

--- a/client/PlayerList.jsx
+++ b/client/PlayerList.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { GameStateContext } from './GameStateContext.js';
+import Portrait from './components/Portrait.jsx';
 
 /**
  * Displays the list of players in seating order with indicators
@@ -7,7 +8,7 @@ import { GameStateContext } from './GameStateContext.js';
  * shown but marked as dead.
  */
 export default function PlayerList() {
-  const { gameState } = useContext(GameStateContext);
+  const { gameState, playerId } = useContext(GameStateContext);
   const game = gameState.game;
   if (!game) return null;
 
@@ -19,8 +20,17 @@ export default function PlayerList() {
           const isPresident = idx === game.presidentIndex;
           const isChancellor = idx === game.chancellorIndex;
           const deadStyles = !p.alive ? 'line-through text-gray-500' : '';
+          const revealed = p.isRevealedTo?.includes(playerId) || p.id === playerId;
+          const variant = revealed
+            ? p.role === 'HITLER'
+              ? 'hitler'
+              : p.role === 'FASCIST'
+              ? 'fascist'
+              : 'neutral'
+            : 'neutral';
           return (
-            <li key={p.id} className={`flex items-center ${deadStyles}`}>
+            <li key={p.id} className={`flex items-center space-x-2 ${deadStyles}`}>
+              <Portrait portraitId={p.portrait} variant={variant} />
               <span className="flex-1">{p.name}</span>
               {!p.alive && (
                 <span className="ml-2 text-gray-600" title="Executed">☠️</span>

--- a/client/components/Portrait.jsx
+++ b/client/components/Portrait.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+export default function Portrait({ portraitId, variant = 'neutral' }) {
+  const [error, setError] = useState(false);
+  if (!portraitId) return null;
+  const src = `/assets/portraits/${portraitId}_${variant}.png`;
+
+  if (error) {
+    return (
+      <div className="portrait-fallback">
+        <span>?</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={portraitId}
+      onError={() => setError(true)}
+      className="w-20 h-20 object-cover"
+    />
+  );
+}

--- a/client/global.css
+++ b/client/global.css
@@ -2,3 +2,14 @@
 body {
   font-family: sans-serif;
 }
+
+.portrait-fallback {
+  width: 80px;
+  height: 80px;
+  background: black;
+  color: white;
+  font-size: 2em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/server/bots/BotManager.js
+++ b/server/bots/BotManager.js
@@ -1,13 +1,15 @@
 "use strict";
 
-const { ROLES } = require("../../shared/constants.js");
+const { ROLES, AVAILABLE_PORTRAITS } = require("../../shared/constants.js");
 const { createBot } = require("./BotEngine.js");
 
 const botsByRoom = {};
 
 function addBotToRoom(room, role, name) {
+  const portrait = AVAILABLE_PORTRAITS[Math.floor(Math.random() * AVAILABLE_PORTRAITS.length)];
   const bot = createBot(role, name);
-  room.players.push({ id: name, name, role, socketId: null });
+  bot.portrait = portrait;
+  room.players.push({ id: name, name, role, socketId: null, portrait });
   if (!botsByRoom[room.code]) botsByRoom[room.code] = [];
   botsByRoom[room.code].push(bot);
   return bot;

--- a/server/index.js
+++ b/server/index.js
@@ -88,16 +88,16 @@ function sendPendingPrompts(socket, room, playerId) {
 io.on('connection', (socket) => {
   console.log('Client connected:', socket.id);
 
-  socket.on(MESSAGE_TYPES.CREATE_ROOM, ({ name, playerId }) => {
+  socket.on(MESSAGE_TYPES.CREATE_ROOM, ({ name, portrait, playerId }) => {
     const id = playerId || randomUUID();
-    const player = { id, name, socketId: socket.id };
+    const player = { id, name, socketId: socket.id, portrait };
     const code = roomManager.createRoom(player);
     socket.join(code);
     socket.emit(MESSAGE_TYPES.ASSIGN_PLAYER_ID, { playerId: id, roomCode: code });
     emitRoomUpdate(code);
   });
 
-  socket.on(MESSAGE_TYPES.JOIN_ROOM, ({ name, roomCode, playerId }) => {
+  socket.on(MESSAGE_TYPES.JOIN_ROOM, ({ name, roomCode, playerId, portrait }) => {
     const room = roomManager.getRoomByCode(roomCode);
     if (!room) {
       socket.emit(MESSAGE_TYPES.ROOM_UPDATE, { error: 'Room not found' });
@@ -108,6 +108,7 @@ io.on('connection', (socket) => {
       const existing = room.players.find((p) => p.id === playerId);
       if (existing) {
         existing.name = name || existing.name;
+        if (portrait) existing.portrait = portrait;
         existing.socketId = socket.id;
         socket.join(roomCode);
         socket.emit(MESSAGE_TYPES.ASSIGN_PLAYER_ID, { playerId, roomCode });
@@ -126,7 +127,7 @@ io.on('connection', (socket) => {
     }
 
     const id = playerId || randomUUID();
-    const player = { id, name, socketId: socket.id };
+    const player = { id, name, socketId: socket.id, portrait };
     if (roomManager.joinRoom(roomCode, player)) {
       socket.join(roomCode);
       socket.emit(MESSAGE_TYPES.ASSIGN_PLAYER_ID, { playerId: id, roomCode });

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -27,6 +27,18 @@ const POWERS = Object.freeze({
   EXECUTION: 'EXECUTION',
 });
 
+// Available portrait IDs
+const AVAILABLE_PORTRAITS = [
+  'owl',
+  'fox',
+  'robot',
+  'pirate',
+  'alien',
+  'witch',
+  'cat',
+  'deer',
+];
+
 // Mapping of fascist policy count to powers based on player count
 // Index 0 corresponds to the first enacted fascist policy, etc.
 const FASCIST_POWERS = {
@@ -90,4 +102,5 @@ module.exports = {
   POWERS,
   FASCIST_POWERS,
   ROLE_DISTRIBUTION,
+  AVAILABLE_PORTRAITS,
 };


### PR DESCRIPTION
## Summary
- store portraits on players and bots
- pick from a new portrait list in `Lobby`
- show player portraits in the list with role-based variants
- fallback CSS when portrait images fail to load
- allow committing `public/assets/portraits` via `.gitignore`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea8d14580832a94d88b9946de2e8f