### PR TITLE
Enforce ESM across client/shared and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This project lays the groundwork for a multiplayer implementation of **Secret Hi
 - **Backend**: Node.js + socket.io
 - **Shared**: Common constants and utilities across client and server
 
+> **Note**
+> The `/client` and `/shared` folders use ECMAScript Modules. Always import with
+> ESM `import` syntax and include the `.js` extension for local paths.
+
 ## Getting Started
 1. Install dependencies in both the client and server:
    ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -16,10 +16,12 @@
 - Reconnection support for players who refresh or temporarily lose connection
 - Polish layout for main game UI components
 - Build step for bundling client scripts and global styles
+- Convert `shared/messages.js` to ESM
 
 ## 🔨 In Progress
 - Additional UX cues for executed players and game over screens
 - Add proper routing or state machine to manage phases
+- ❗ Audit backend for consistent module format
 
 ## 🕳️ Missing / Skipped Logic
 =======

--- a/server/bots/BotEngine.js
+++ b/server/bots/BotEngine.js
@@ -1,6 +1,4 @@
-"use strict";
-
-const { ROLES, POWERS } = require("../../shared/constants.js");
+import { ROLES, POWERS } from "../../shared/constants.js";
 
 /**
  * Creates a basic bot agent for Secret Hitler.
@@ -144,4 +142,5 @@ function clamp(min, max, val) {
   return Math.max(min, Math.min(max, val));
 }
 
-module.exports = { createBot };
+export { createBot };
+

--- a/server/bots/BotManager.js
+++ b/server/bots/BotManager.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const { ROLES, AVAILABLE_PORTRAITS } = require("../../shared/constants.js");
-const { createBot } = require("./BotEngine.js");
+import { ROLES, AVAILABLE_PORTRAITS } from "../../shared/constants.js";
+import { createBot } from "./BotEngine.js";
 
 const botsByRoom = {};
 
@@ -35,7 +33,7 @@ function spawnForSolo(room, playerNames) {
   }
 }
 
-module.exports = {
+export {
   addBotToRoom,
   removeBots,
   getBots,

--- a/server/chat.js
+++ b/server/chat.js
@@ -1,6 +1,4 @@
-const { PHASES } = require('../shared/constants.js');
-
-function sanitizeMessage(str) {
+export function sanitizeMessage(str) {
   if (!str) return '';
   return String(str).replace(/<[^>]*>/g, '').replace(/[<>]/g, '');
 }
@@ -28,7 +26,7 @@ function determineRecipients(room, to) {
   return recipients;
 }
 
-function prepareChat(room, fromId, text, to = 'global') {
+export function prepareChat(room, fromId, text, to = 'global') {
   if (!room || !room.game) return null;
   const fromPlayer = room.players.find(p => p.id === fromId);
   if (!fromPlayer) return null;
@@ -41,4 +39,3 @@ function prepareChat(room, fromId, text, to = 'global') {
   return { entry, socketIds, visibility };
 }
 
-module.exports = { sanitizeMessage, prepareChat };

--- a/server/gameEngine.js
+++ b/server/gameEngine.js
@@ -2,8 +2,8 @@
  * Game engine responsible for handling Secret Hitler logic.
  * All logic should be server-side and authoritative.
  */
-const { ROLES, PHASES, POWERS, FASCIST_POWERS } = require('../shared/constants.js');
-const { assignRoles, shuffleDeck } = require('../shared/utils.js');
+import { ROLES, PHASES, POWERS, FASCIST_POWERS } from '../shared/constants.js';
+import { assignRoles, shuffleDeck } from '../shared/utils.js';
 
 const BASE_POLICY_DECK = [
   ...Array(6).fill('LIBERAL'),
@@ -593,7 +593,7 @@ function handleDisconnect(room, playerId) {
   return null;
 }
 
-module.exports = {
+export {
   startGame,
   handleVote,
   processPolicy,

--- a/server/index.js
+++ b/server/index.js
@@ -1,14 +1,18 @@
-const express = require('express');
-const http = require('http');
-const { Server } = require('socket.io');
-const cors = require('cors');
-const { randomUUID } = require('crypto');
-const path = require('path');
-const roomManager = require('./roomManager.js');
-const gameEngine = require('./gameEngine.js');
-const { MESSAGE_TYPES } = require('../shared/messages.js');
-const { PHASES, POWERS, ROLES } = require('../shared/constants.js');
-const { prepareChat } = require('./chat.js');
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import cors from 'cors';
+import { randomUUID } from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as roomManager from './roomManager.js';
+import * as gameEngine from './gameEngine.js';
+import { MESSAGE_TYPES } from '../shared/messages.js';
+import { PHASES, POWERS, ROLES } from '../shared/constants.js';
+import { prepareChat } from './chat.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /**
  * Initializes express and socket.io server.
@@ -444,3 +448,4 @@ const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
+

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,7 @@
   "name": "secret-hitler-server",
   "private": true,
   "version": "0.1.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -2,7 +2,7 @@
  * Simple in-memory room manager.
  * NOTE: replace with persistent storage if scaling to multiple servers.
  */
-const { generateRoomCode } = require('../shared/utils.js');
+import { generateRoomCode } from '../shared/utils.js';
 
 const rooms = {};
 
@@ -78,7 +78,7 @@ function listRooms() {
   return Object.keys(rooms);
 }
 
-module.exports = {
+export {
   createRoom,
   joinRoom,
   removePlayer,

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -3,14 +3,14 @@
  */
 
 // Player roles
-const ROLES = Object.freeze({
+export const ROLES = Object.freeze({
   LIBERAL: 'LIBERAL',
   FASCIST: 'FASCIST',
   HITLER: 'HITLER',
 });
 
 // Game phases
-const PHASES = Object.freeze({
+export const PHASES = Object.freeze({
   NOMINATE: 'NOMINATE',
   VOTE: 'VOTE',
   POLICY: 'POLICY',
@@ -19,7 +19,7 @@ const PHASES = Object.freeze({
 });
 
 // Presidential powers
-const POWERS = Object.freeze({
+export const POWERS = Object.freeze({
   NONE: 'NONE',
   INVESTIGATE: 'INVESTIGATE',
   SPECIAL_ELECTION: 'SPECIAL_ELECTION',
@@ -28,7 +28,7 @@ const POWERS = Object.freeze({
 });
 
 // Available portrait IDs
-const AVAILABLE_PORTRAITS = [
+export const AVAILABLE_PORTRAITS = [
   'owl',
   'fox',
   'robot',
@@ -41,7 +41,7 @@ const AVAILABLE_PORTRAITS = [
 
 // Mapping of fascist policy count to powers based on player count
 // Index 0 corresponds to the first enacted fascist policy, etc.
-const FASCIST_POWERS = {
+export const FASCIST_POWERS = {
   5: [
     POWERS.NONE,
     POWERS.NONE,
@@ -87,7 +87,7 @@ const FASCIST_POWERS = {
 };
 
 // Mapping of player count to roles
-const ROLE_DISTRIBUTION = {
+export const ROLE_DISTRIBUTION = {
   5: { liberals: 3, fascists: 1, hitler: 1 },
   6: { liberals: 4, fascists: 1, hitler: 1 },
   7: { liberals: 4, fascists: 2, hitler: 1 },
@@ -96,11 +96,4 @@ const ROLE_DISTRIBUTION = {
   10: { liberals: 6, fascists: 3, hitler: 1 },
 };
 
-module.exports = {
-  ROLES,
-  PHASES,
-  POWERS,
-  FASCIST_POWERS,
-  ROLE_DISTRIBUTION,
-  AVAILABLE_PORTRAITS,
-};
+

--- a/shared/messages.js
+++ b/shared/messages.js
@@ -2,7 +2,7 @@
  * Socket message type constants for client/server communication.
  */
 
-const MESSAGE_TYPES = Object.freeze({
+export const MESSAGE_TYPES = Object.freeze({
   CREATE_ROOM: 'CREATE_ROOM',
   JOIN_ROOM: 'JOIN_ROOM',
   LEAVE_ROOM: 'LEAVE_ROOM',
@@ -31,6 +31,3 @@ const MESSAGE_TYPES = Object.freeze({
   CHAT_RECEIVE: 'chat:receive',
 });
 
-module.exports = {
-  MESSAGE_TYPES,
-};

--- a/shared/tips.js
+++ b/shared/tips.js
@@ -6,9 +6,9 @@
  * @param {string} role Player's secret role (LIBERAL/FASCIST/HITLER)
  * @returns {string[]} Array of suggestion strings
  */
-const { PHASES, ROLES, POWERS } = require('./constants.js');
+import { PHASES, ROLES, POWERS } from './constants.js';
 
-function getTipsForPlayer(game, playerId, role) {
+export function getTipsForPlayer(game, playerId, role) {
   if (!game) return [];
   const tips = [];
   const meIdx = game.players.findIndex((p) => p.id === playerId);
@@ -83,4 +83,4 @@ function getTipsForPlayer(game, playerId, role) {
   return tips;
 }
 
-module.exports = { getTipsForPlayer };
+

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -6,7 +6,7 @@
  * Shuffles an array in place and returns it.
  * @param {Array} deck
  */
-function shuffleDeck(deck) {
+export function shuffleDeck(deck) {
   for (let i = deck.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [deck[i], deck[j]] = [deck[j], deck[i]];
@@ -18,9 +18,9 @@ function shuffleDeck(deck) {
  * Assigns roles to players based on player count.
  * @param {Array} playerList
  */
-const { ROLE_DISTRIBUTION, ROLES } = require('./constants.js');
+import { ROLE_DISTRIBUTION, ROLES } from './constants.js';
 
-function assignRoles(playerList) {
+export function assignRoles(playerList) {
   const distribution = ROLE_DISTRIBUTION[playerList.length];
   if (!distribution) return playerList;
 
@@ -37,7 +37,7 @@ function assignRoles(playerList) {
 /**
  * Generates a unique room code.
  */
-function generateRoomCode(length = 5) {
+export function generateRoomCode(length = 5) {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
   let code = '';
   for (let i = 0; i < length; i++) {
@@ -46,8 +46,4 @@ function generateRoomCode(length = 5) {
   return code;
 }
 
-module.exports = {
-  shuffleDeck,
-  assignRoles,
-  generateRoomCode,
-};
+


### PR DESCRIPTION
## Summary
- convert shared constants/messages/utils/tips to ESM
- migrate server code to ESM and enable in package.json
- update README with note about ESM imports
- track conversion in TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb5d10738832aba2d0333ae21d85b