### PR TITLE
Fix server health route for Fly.io

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -19,8 +19,11 @@ const __dirname = path.dirname(__filename);
  * Handles basic connection events.
  */
 const app = express();
-app.use(cors({ origin: process.env.CORS_ORIGIN || '*'}));
-app.use(express.static(path.join(__dirname, '..', 'public')));
+app.use(cors({ origin: process.env.CORS_ORIGIN || '*' }));
+app.use(express.json());
+app.use(
+  express.static(path.join(__dirname, '..', 'public'), { index: false })
+);
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
@@ -441,7 +444,7 @@ io.on('connection', (socket) => {
 });
 
 app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+  res.send('Backend running!');
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- parse JSON bodies in Express
- disable automatic index.html serving so `/` can return a simple health message
- add a `/` route that returns `Backend running!`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ebd15c984832a9ef9bde41b6f77f7