### PR TITLE
Fix backend host binding for Fly

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,6 +8,7 @@ app.get('/', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+const HOST = '0.0.0.0';
+app.listen(PORT, HOST, () => {
+  console.log(`Server listening on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- bind mini backend to `0.0.0.0`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec1344a18832abc701075241bc921