### PR TITLE
Fix server imports for Fly deployment

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -1,0 +1,1 @@
+export * from '../shared/constants.js';

--- a/server/index.js
+++ b/server/index.js
@@ -7,8 +7,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import * as roomManager from './roomManager.js';
 import * as gameEngine from './gameEngine.js';
-import { MESSAGE_TYPES } from '../shared/messages.js';
-import { PHASES, POWERS, ROLES } from '../shared/constants.js';
+import { MESSAGE_TYPES } from './messages.js';
+import { PHASES, POWERS, ROLES } from './constants.js';
 import { prepareChat } from './chat.js';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/server/messages.js
+++ b/server/messages.js
@@ -1,0 +1,1 @@
+export * from '../shared/messages.js';


### PR DESCRIPTION
## Summary
- adjust server index imports to use local re-exports
- add re-export files for message types and constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec2b7afb8832aa06662bc49a79a95